### PR TITLE
[FEAT] Spring Rest Docs 적용하기

### DIFF
--- a/backend/platform_server/build.gradle
+++ b/backend/platform_server/build.gradle
@@ -1,3 +1,39 @@
+plugins {
+    // AsciiDoc 파일을 컨버팅하고 Build 폴더에 복사하기 위한 플러그인입니다.
+    id "org.asciidoctor.convert" version "1.5.9.2"
+}
+
 dependencies {
     compile project(':backend:core')
+    asciidoctor 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation('org.springframework.restdocs:spring-restdocs-mockmvc')
+    testImplementation('org.springframework.boot:spring-boot-starter-test') {
+        exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+    }
+}
+
+ext {
+    snippetsDir = file('build/generated-snippets')          // (2)
+}
+
+test {
+    outputs.dir snippetsDir
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    // gradle build 시 test -> asciidoctor 순으로 수행됩니다.
+    dependsOn test
+}
+
+
+bootJar {
+    // gradle build 시 asciidoctor -> bootJar 순으로 수행됩니다.
+    dependsOn asciidoctor
+
+    // gradle build 시 ./build/asciidoc/html5/ 에 html 파일이 생깁니다.
+    // 이것을 jar 안에 /static/docs/ 폴더에 복사가 됩니다.
+    from ("${asciidoctor.outputDir}/html5") {
+        into 'static/docs'
+    }
 }

--- a/backend/platform_server/build.gradle
+++ b/backend/platform_server/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     // AsciiDoc 파일을 컨버팅하고 Build 폴더에 복사하기 위한 플러그인입니다.
-    id "org.asciidoctor.convert" version "1.5.9.2"
+    id "org.asciidoctor.convert" version "1.5.10"
 }
 
 dependencies {

--- a/backend/platform_server/src/docs/asciidoc/api-docs.adoc
+++ b/backend/platform_server/src/docs/asciidoc/api-docs.adoc
@@ -1,0 +1,47 @@
+= WWW(wow-welcome-webtoon) API Document
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toc-title: 목차
+:toclevels: 2
+:sectlinks:
+//:operation-curl-request-title: Example request
+//:operation-http-response-title: Example response
+
+[[introduction-platform]]
+= 플랫폼 서버
+
+Platform Server API 문서
+
+현재 플랫폼 서버 port는 8082를 사용합니다.
+
+
+[[Comments]]
+== 댓글 시스템
+
+[[Comments-get]]
+=== GET 댓글 목록 조회
+페이지 번호에 따른 댓글 조회
+
+operation::Comments-controller-test/get-comments[snippets='http-request,path-parameters,request-parameters,http-response,response-fields']
+
+
+=== GET 베스트 댓글 목록 조회
+
+=== GET 마이페이지 내가 쓴 댓글 조회
+
+=== POST 댓글 등록
+
+=== POST 댓글 좋아요 요청
+
+=== POST 댓글 싫어요 요청
+
+=== DEL 댓글 삭제
+
+
+
+== 별점 시스템
+
+=== POST 회차 별점 주기(등록)
+

--- a/backend/platform_server/src/main/java/com/www/platform/PlatformApplication.java
+++ b/backend/platform_server/src/main/java/com/www/platform/PlatformApplication.java
@@ -9,8 +9,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication(scanBasePackages = "com.www")
-@EntityScan(basePackages = "com.www.core")
-@EnableJpaRepositories(basePackages = "com.www.core")
+// @EntityScan(basePackages = "com.www.core")
+// @EnableJpaRepositories(basePackages = "com.www.core")
 //@EnableJpaAuditing
 public class PlatformApplication {
     public static void main(String[] args) {

--- a/backend/platform_server/src/test/java/com/www/platform/controller/CommentsControllerTest.java
+++ b/backend/platform_server/src/test/java/com/www/platform/controller/CommentsControllerTest.java
@@ -19,6 +19,9 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import org.springframework.test.web.servlet.ResultActions;
@@ -31,10 +34,11 @@ import java.util.stream.Collectors;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+//import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 
 @ExtendWith(RestDocumentationExtension.class)
 @WebMvcTest(controllers = CommentsController.class)
@@ -105,16 +109,34 @@ public class CommentsControllerTest {
                 .willReturn(response);
 
         //when
-        ResultActions result = mockMvc.perform(get("/episodes/{ep_idx}/comments", episodeIdx)
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/episodes/{ep_idx}/comments", episodeIdx)
                 .param("page", page)
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON));
+                .contentType(MediaType.APPLICATION_JSON));
 
         //then
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("code").value(0))
                 .andExpect(jsonPath("msg").value("request complete : get comments by page request"))
                 .andExpect(jsonPath("data.comments[0].idx").value(5))
-                .andExpect(jsonPath("data.total_pages").value(1));
+                .andExpect(jsonPath("data.total_pages").value(1))
+                .andDo(document("{class-name}/{method-name}",
+                        pathParameters(
+                                parameterWithName("ep_idx").description("에피소드의 idx")
+                        ),
+                        requestParameters(
+                                parameterWithName("page").description("페이지 번호")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("응답 코드"),
+                                fieldWithPath("msg").description("응답 메시지"),
+                                fieldWithPath("data.comments[]").description("댓글 목록").type(JsonFieldType.ARRAY),
+                                fieldWithPath("data.comments.[].idx").description("댓글 기본 idx").type(JsonFieldType.NUMBER),
+                                fieldWithPath("data.comments.[].user_id").description("유저 아이디").type(JsonFieldType.STRING),
+                                fieldWithPath("data.comments.[].like_cnt").description("좋아요 수").type(JsonFieldType.NUMBER),
+                                fieldWithPath("data.comments.[].dislike_cnt").description("싫어요 수").type(JsonFieldType.NUMBER),
+                                fieldWithPath("data.comments.[].content").description("댓글 내용").type(JsonFieldType.STRING),
+                                fieldWithPath("data.comments.[].created_date").description("땟글 생성일").type(JsonFieldType.STRING),
+                                fieldWithPath("data.total_pages").description("총 페이지 수").type(JsonFieldType.NUMBER)
+                        )));
     }
 }

--- a/backend/platform_server/src/test/java/com/www/platform/controller/CommentsControllerTest.java
+++ b/backend/platform_server/src/test/java/com/www/platform/controller/CommentsControllerTest.java
@@ -1,10 +1,120 @@
 package com.www.platform.controller;
 
+import com.www.core.auth.entity.Users;
+import com.www.core.common.Response;
+import com.www.core.common.TokenChecker;
+import com.www.core.file.entity.Episode;
+import com.www.core.platform.entity.Comments;
+import com.www.platform.dto.CommentsDto;
+import com.www.platform.dto.CommentsResponseDto;
+import com.www.platform.service.CommentsLikeDislikeService;
+import com.www.platform.service.CommentsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 
 @ExtendWith(RestDocumentationExtension.class)
+@WebMvcTest(controllers = CommentsController.class)
 public class CommentsControllerTest {
 
+    @MockBean
+    private CommentsService commentsService;
+    @MockBean
+    private CommentsLikeDislikeService commentsLikeDislikeService;
+    @MockBean
+    private TokenChecker tokenChecker;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp(WebApplicationContext context,
+               RestDocumentationContextProvider restDocumentation) {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(documentationConfiguration(restDocumentation))
+                .alwaysDo(print())
+                .build();
+    }
+
+    @DisplayName("댓글 페이징 조회")
+    @Test
+    void getComments() throws Exception {
+        //given
+        Users user = Users.builder()
+                .idx(1)
+                .id("id123")
+                .name("철수")
+                .e_pw("1q2w3e4r")
+                .gender(0)
+                .email("test@email.com")
+                .build();
+        Episode episode = Episode.builder()
+                .idx(1)
+                .ep_no(1)
+                .title("에피소드 제목")
+                .author_comment("작가의 말")
+                .build();
+
+        int episodeIdx = 1;
+        String page = "1";
+        int pageNumber = Integer.parseInt(page);
+        List<Comments> commentsList = new ArrayList<>();
+        for (int idx = 5; idx >= 1; idx--) {
+            commentsList.add(Comments.builder()
+                    .idx(idx)
+                    .users(user)
+                    .ep(episode)
+                    .content("댓글 내용 " + idx)
+                    .build());
+        }
+        CommentsResponseDto commentsResponseDto = CommentsResponseDto.builder()
+                .comments(commentsList.stream()
+                        .map(CommentsDto::new)
+                        .collect(Collectors.toList()))
+                .total_pages(1)
+                .build();
+
+        Response<CommentsResponseDto> response = new Response<>();
+        response.setCode(0);
+        response.setMsg("request complete : get comments by page request");
+        response.setData(commentsResponseDto);
+        given(commentsService.getCommentsByPageRequest(episodeIdx, pageNumber))
+                .willReturn(response);
+
+        //when
+        ResultActions result = mockMvc.perform(get("/episodes/{ep_idx}/comments", episodeIdx)
+                .param("page", page)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+        //then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("code").value(0))
+                .andExpect(jsonPath("msg").value("request complete : get comments by page request"))
+                .andExpect(jsonPath("data.comments[0].idx").value(5))
+                .andExpect(jsonPath("data.total_pages").value(1));
+    }
 }

--- a/backend/platform_server/src/test/java/com/www/platform/controller/CommentsControllerTest.java
+++ b/backend/platform_server/src/test/java/com/www/platform/controller/CommentsControllerTest.java
@@ -36,15 +36,13 @@ import java.util.stream.Collectors;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 
 @ExtendWith(RestDocumentationExtension.class)
 @WebMvcTest(controllers = CommentsController.class)
@@ -66,7 +64,7 @@ public class CommentsControllerTest {
     void setUp(WebApplicationContext context,
                RestDocumentationContextProvider restDocumentation) {
         documentationHandler = document("{class-name}/{method-name}",
-                preprocessRequest(prettyPrint()),
+                preprocessRequest(prettyPrint(), modifyUris().removePort()),
                 preprocessResponse(prettyPrint()));
 
         mockMvc = MockMvcBuilders.webAppContextSetup(context)
@@ -99,7 +97,7 @@ public class CommentsControllerTest {
         String page = "1";
         int pageNumber = Integer.parseInt(page);
         List<Comments> commentsList = new ArrayList<>();
-        for (int idx = 5; idx >= 1; idx--) {
+        for (int idx = 3; idx >= 1; idx--) {
             commentsList.add(Comments.builder()
                     .idx(idx)
                     .users(user)
@@ -130,14 +128,14 @@ public class CommentsControllerTest {
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("code").value(0))
                 .andExpect(jsonPath("msg").value("request complete : get comments by page request"))
-                .andExpect(jsonPath("data.comments[0].idx").value(5))
+                .andExpect(jsonPath("data.comments[0].idx").value(3))
                 .andExpect(jsonPath("data.total_pages").value(1))
                 .andDo(this.documentationHandler.document(
                         pathParameters(
                                 parameterWithName("ep_idx").description("에피소드의 idx")
                         ),
                         requestParameters(
-                                parameterWithName("page").description("페이지 번호")
+                                parameterWithName("page").description("페이지 번호 (1 이상)")
                         ),
                         responseFields(
                                 fieldWithPath("code").description("응답 코드"),

--- a/backend/platform_server/src/test/java/com/www/platform/controller/CommentsControllerTest.java
+++ b/backend/platform_server/src/test/java/com/www/platform/controller/CommentsControllerTest.java
@@ -1,0 +1,10 @@
+package com.www.platform.controller;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+@ExtendWith(RestDocumentationExtension.class)
+public class CommentsControllerTest {
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -11,17 +11,14 @@ buildscript {
     }
 }
 
-allprojects {
-    group 'com.www'
-    version '1.0-SNAPSHOT'
-}
-
 subprojects {
     apply plugin: 'java'
     apply plugin: 'org.springframework.boot'
     apply plugin: 'io.spring.dependency-management'
     apply plugin: 'jacoco'
 
+    group 'com.www'
+    version '1.0-SNAPSHOT'
     sourceCompatibility = 1.8
 
     repositories {
@@ -74,14 +71,7 @@ subprojects {
 
     dependencies {
         implementation ('org.springframework.boot:spring-boot-starter-actuator')
-        implementation ('org.springframework.boot:spring-boot-starter-data-jpa')
-        implementation ('org.springframework.boot:spring-boot-starter-web')
         compileOnly ('org.projectlombok:lombok')
         annotationProcessor ('org.projectlombok:lombok')
-        testImplementation('org.springframework.boot:spring-boot-starter-test') {
-            exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
-        }
     }
-
-
 }


### PR DESCRIPTION
# issue : #13 

## API 문서 자동화를 위해 Spring Rest Docs 도입
 - Spring Rest Docs 적용을 위한 브랜치로 모든 controller에 대한 test는 아직 미작성
 - 임시로 플랫폼 서버 모듈의 CommentsController에서 댓글 조회 기능만 test code 작성하고 문서화 코드 작성

## TODO
 - 플랫폼 서버 모듈내의 모든 controller test code작성 후 문서화
 - 다른 서버 모듈의 controller test code 작성 후 문서화
 - 커스텀하기
   - 공통 포맷(code, msg, data) 따로 정리
   - Error 응답 데이터 따로 정리 
 - 기타 등

## 예시 화면

![example-spring-rest-docs](https://user-images.githubusercontent.com/34932546/115106154-289da000-9f9e-11eb-89c7-ad41cc04de67.png)


